### PR TITLE
Working around the inability of creating an O365 connection after creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@ A Terraform template for annoying your friends and/or co-workers with Cat Facts 
 
 
 You will need to update the 5 variables at the top of the file with the appropriate values as well as create a connection to Office 365 using the account you wish to email from.
+
+There is no way to add the O365 connection after this workflow app has been provisioned. Currently the module will sleep for a configurable 60 seconds, allowing the user time to open the Azure console, go to the newly created Cat-Facts-App and manually add a step that will create an O365 connection. I recommend the "Get Calendars" task as it doesn't require any additional configuration. Once this is completed the final logic app action will be deployed and will automatically use the newly created O365 connection.
+
+## Module usage
+```terraform
+module "MY_TEST_CATFACT" {
+  source = "github.com/WarpRat/cat-facts"
+
+  organization_name               = "Contoso"
+  distribution_list_email_address = "root@whitehouse.gov"
+  location                        = "WestUS2"
+  city                            = "Seattle"
+  your_name                       = "Macaulay Culkin"
+  boss_name                       = "Joe Pesci"
+}
+```

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "cat_fact_workflow_id" {
+  description = "The workflow ID of this azure cat fact logic workflow"
+  value       = "${azurerm_logic_app_workflow.cat-facts-workflow.id}"
+}

--- a/test/cat-fact.tf
+++ b/test/cat-fact.tf
@@ -1,0 +1,10 @@
+module "MY_TEST_CATFACT" {
+  source = "../"
+
+  organization_name               = "Contoso"
+  distribution_list_email_address = "root@whitehouse.gov"
+  location                        = "WestUS2"
+  city                            = "Seattle"
+  your_name                       = "Macaulay Culkin"
+  boss_name                       = "Joe Pesci"
+}

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,4 @@
+# Configure the Azure Provider
+provider "azurerm" {
+  version = "=1.28.0"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,31 @@
+variable "organization_name" {
+  description = "(Required) Your organization's name"
+}
+
+variable "distribution_list_email_address" {
+  description = "(Required) The distribution list to send cat facts to."
+}
+
+variable "location" {
+  description = "(Optional) Which Azure location to launch Cat Facts in."
+  default     = "canadacentral"
+}
+
+variable "city" {
+  description = "(Required) Your city"
+}
+
+variable "your_name" {
+  description = "(Optional) Your name"
+  default     = "A kind stranger"
+}
+
+variable "boss_name" {
+  description = "(Optional) Your boss' name"
+  default     = "Someone who cares"
+}
+
+variable "sleep_time" {
+  description = "(Optional) How long do you need to go connect this workflow app to an O365 account for sending email."
+  default     = "60"
+}


### PR DESCRIPTION
I couldn't get this to work properly as it was. I got an error about $connections not being a valid parameter. As far as I can tell the only way to create an O365 connection is by manually adding a O365 action and signing in. If there is a better way please let me know, this is a real hacky work around. 

Also restructured it to work as a terraform module. This version requires terraform <=0.11 if I don't get bored with it I'll probably do a terraform ~>0.12 too.